### PR TITLE
Change admin profile details to improve UX

### DIFF
--- a/components/org.wso2.carbon.ldap.server/src/main/resources/embedded-ldap.xml
+++ b/components/org.wso2.carbon.ldap.server/src/main/resources/embedded-ldap.xml
@@ -48,8 +48,7 @@
   <!-- Default partition admin configurations -->
   <PartitionAdmin>
     <Property name="uid">admin</Property>
-    <Property name="firstName">admin</Property>
-    <Property name="lastName">admin</Property>
+    <Property name="lastName">Administrator</Property>
     <Property name="email">admin@wso2.com</Property>
     <Property name="password">admin</Property>
     <Property name="passwordType">SHA</Property>

--- a/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/embedded-ldap.xml
+++ b/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/embedded-ldap.xml
@@ -103,8 +103,7 @@
   -->
   <PartitionAdmin>
     <Property name="uid">admin</Property>
-    <Property name="firstName">admin</Property>
-    <Property name="lastName">admin</Property>
+    <Property name="lastName">Administrator</Property>
     <Property name="email">admin@wso2.com</Property>
     <Property name="password">admin</Property>
     <Property name="passwordType">SHA</Property>


### PR DESCRIPTION
$subject. Resolves wso2/product-is#6735

Updating the fix done in https://github.com/wso2-extensions/identity-userstore-ldap/pull/30 to avoid having not-null content to lastname (sn attribute), since having sn attribute null caused problems in integration tests in product-is.

Verified product integration tests with the change.