### PR TITLE
Update p2.inf file to pack embedded-ldap.xml.j2 to product IS

### DIFF
--- a/features/org.wso2.carbon.ldap.server.server.feature/pom.xml
+++ b/features/org.wso2.carbon.ldap.server.server.feature/pom.xml
@@ -73,6 +73,8 @@
                                     <directory>resources</directory>
                                     <includes>
                                         <include>conf/embedded-ldap.xml</include>
+                                        <include>conf/embedded-ldap.xml.j2</include>
+                                        <include>conf/*.json</include>
                                         <include>conf/is-default-schema.zip</include>
                                         <include>conf/identityPerson.ldif</include>
                                         <include>conf/scimPerson.ldif</include>

--- a/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/embedded-ldap.xml.j2
+++ b/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/embedded-ldap.xml.j2
@@ -103,8 +103,7 @@
   -->
   <PartitionAdmin>
     <Property name="uid">admin</Property>
-    <Property name="firstName">admin</Property>
-    <Property name="lastName">admin</Property>
+    <Property name="lastName">Administrator</Property>
     <Property name="email">admin@wso2.com</Property>
     <Property name="password">admin</Property>
     <Property name="passwordType">SHA</Property>

--- a/features/org.wso2.carbon.ldap.server.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.ldap.server.server.feature/resources/p2.inf
@@ -7,4 +7,13 @@ org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../featur
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.ldap.server.server_${feature.version}/conf/scimPerson.ldif,target:${installFolder}/../../resources/identity/ldif/scimPerson.ldif,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.ldap.server.server_${feature.version}/conf/identityPerson.ldif,target:${installFolder}/../../resources/identity/ldif/identityPerson.ldif,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.ldap.server.server_${feature.version}/conf/embedded-ldap.xml,target:${installFolder}/../../conf/identity/embedded-ldap.xml,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf/templates); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf/templates/repository); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf/templates/repository/conf); \
+org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/../../../repository/resources/conf/templates/repository/conf/identity); \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.ldap.server.server_${feature.version}/conf/embedded-ldap.xml.j2,target:${installFolder}/../../resources/conf/templates/repository/conf/identity/embedded-ldap.xml.j2,overwrite:true);\
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.ldap.server.server_${feature.version}/conf/org.wso2.carbon.ldap.server.server.feature.default.json,target:${installFolder}/../../resources/conf/org.wso2.carbon.ldap.server.server.feature.default.json,overwrite:true);\
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.ldap.server.server_${feature.version}/conf/is-default-schema.zip,target:${installFolder}/../../data/is-default-schema.zip,overwrite:true);\


### PR DESCRIPTION
Partially fixes https://github.com/wso2/product-is/issues/8632
Resolves https://github.com/wso2/product-is/issues/8363

### Proposed changes in this pull request
Although the embedded-ldap.xml.j2 file is added with PR https://github.com/wso2-extensions/identity-userstore-ldap/pull/35, the p2.inf file is not updated to pack the embedded-ldap.xml.j2 file to the product IS. Hence this PR will resolve this issue.
