### PR TITLE
Add attribute to store verification pending mobile number

### DIFF
--- a/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/identityPerson.ldif
+++ b/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/identityPerson.ldif
@@ -166,6 +166,6 @@ objectClasses: ( 1.3.6.1.4.1.37505.1.101
     SUP scimPerson
     STRUCTURAL
     MAY  ( primaryChallenges $ challenges $ firstChallenge $ secondChallenge $ oneTimePassword $ accountLock $ temporaryEmail $ recoveryEmail $ passwordChangeRequired $ passwordTimestamp $ temporaryLock $ lastFailedAttemptTime $ failedLoginAttempts $ lastLogonTime $ unlockTime $ verifyEmail $ askPassword $ forcePasswordReset $ failedRecoveryAttempts $ primaryChallengeQuestion $ emailVerified $ challengeQuestionUris $ 
-    $ lastLoginTime $ lastPasswordUpdate $ phoneVerified $ accountDisabled $ preferredChannel $ lockedReason $ pendingMobileNumber )
+    $ lastLoginTime $ lastPasswordUpdate $ phoneVerified $ accountDisabled $ preferredChannel $ lockedReason $ pendingEmailAddress $ pendingMobileNumber)
  )
 -

--- a/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/identityPerson.ldif
+++ b/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/identityPerson.ldif
@@ -152,6 +152,12 @@ attributeTypes: ( 1.3.6.1.4.1.37505.1.79
         EQUALITY caseIgnoreMatch
         SUBSTR caseIgnoreSubstringsMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+attributeTypes: ( 1.3.6.1.4.1.37505.1.80
+        NAME 'pendingMobileNumber'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+
 -
 add: objectClasses
 objectClasses: ( 1.3.6.1.4.1.37505.1.101
@@ -160,6 +166,6 @@ objectClasses: ( 1.3.6.1.4.1.37505.1.101
     SUP scimPerson
     STRUCTURAL
     MAY  ( primaryChallenges $ challenges $ firstChallenge $ secondChallenge $ oneTimePassword $ accountLock $ temporaryEmail $ recoveryEmail $ passwordChangeRequired $ passwordTimestamp $ temporaryLock $ lastFailedAttemptTime $ failedLoginAttempts $ lastLogonTime $ unlockTime $ verifyEmail $ askPassword $ forcePasswordReset $ failedRecoveryAttempts $ primaryChallengeQuestion $ emailVerified $ challengeQuestionUris $ 
-    $ lastLoginTime $ lastPasswordUpdate $ phoneVerified $ accountDisabled $ preferredChannel $ lockedReason $ pendingEmailAddress)
+    $ lastLoginTime $ lastPasswordUpdate $ phoneVerified $ accountDisabled $ preferredChannel $ lockedReason $ pendingMobileNumber )
  )
 -


### PR DESCRIPTION
### Proposed changes in this pull request

Adds a new attribute to store the newly updated mobile number until it is verified by the user.

Related to issue - https://github.com/wso2/product-is/issues/9045