### PR TITLE
Add attribute to store account confirmed time.

### DIFF
--- a/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/identityPerson.ldif
+++ b/features/org.wso2.carbon.ldap.server.server.feature/resources/conf/identityPerson.ldif
@@ -157,6 +157,11 @@ attributeTypes: ( 1.3.6.1.4.1.37505.1.80
         EQUALITY caseIgnoreMatch
         SUBSTR caseIgnoreSubstringsMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+attributeTypes: ( 1.3.6.1.4.1.37505.1.81
+        NAME 'confirmedTime'
+        EQUALITY caseIgnoreMatch
+        SUBSTR caseIgnoreSubstringsMatch
+        SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
 
 -
 add: objectClasses
@@ -166,6 +171,6 @@ objectClasses: ( 1.3.6.1.4.1.37505.1.101
     SUP scimPerson
     STRUCTURAL
     MAY  ( primaryChallenges $ challenges $ firstChallenge $ secondChallenge $ oneTimePassword $ accountLock $ temporaryEmail $ recoveryEmail $ passwordChangeRequired $ passwordTimestamp $ temporaryLock $ lastFailedAttemptTime $ failedLoginAttempts $ lastLogonTime $ unlockTime $ verifyEmail $ askPassword $ forcePasswordReset $ failedRecoveryAttempts $ primaryChallengeQuestion $ emailVerified $ challengeQuestionUris $ 
-    $ lastLoginTime $ lastPasswordUpdate $ phoneVerified $ accountDisabled $ preferredChannel $ lockedReason $ pendingEmailAddress $ pendingMobileNumber)
+    $ lastLoginTime $ lastPasswordUpdate $ phoneVerified $ accountDisabled $ preferredChannel $ lockedReason $ pendingEmailAddress $ pendingMobileNumber $ confirmedTime)
  )
 -


### PR DESCRIPTION
### Proposed changes in this pull request

Adds a new attribute to store the account confirmed time of a user.

Related to issue - https://github.com/wso2/product-is/issues/9990