### PR TITLE
Update ApacheDS to 2.0.0.M26 and remove ehcache dependency

### DIFF
--- a/components/org.wso2.carbon.ldap.server/src/main/java/org/wso2/carbon/apacheds/impl/ApacheLDAPServer.java
+++ b/components/org.wso2.carbon.ldap.server/src/main/java/org/wso2/carbon/apacheds/impl/ApacheLDAPServer.java
@@ -144,7 +144,7 @@ public class ApacheLDAPServer implements LDAPServer {
     }
 
     @Override
-    public PartitionManager getPartitionManager() throws DirectoryServerException {
+    public PartitionManager getPartitionManager() {
 
         return this.partitionManager;
     }
@@ -373,7 +373,6 @@ public class ApacheLDAPServer implements LDAPServer {
         setupSaslMechanisms();
 
         try {
-            this.ldapServer.addExtendedOperationHandler(new StartTlsHandler());
             this.ldapServer.addExtendedOperationHandler(
                     new StoredProcedureExtendedOperationHandler());
         } catch (Exception e) {

--- a/components/org.wso2.carbon.ldap.server/src/main/java/org/wso2/carbon/apacheds/impl/CarbonDirectoryServiceFactory.java
+++ b/components/org.wso2.carbon.ldap.server/src/main/java/org/wso2/carbon/apacheds/impl/CarbonDirectoryServiceFactory.java
@@ -31,7 +31,6 @@ import org.apache.directory.api.ldap.schema.manager.impl.DefaultSchemaManager;
 import org.apache.directory.api.util.exception.Exceptions;
 import org.apache.directory.server.constants.ServerDNConstants;
 import org.apache.directory.server.core.DefaultDirectoryService;
-import org.apache.directory.server.core.api.CacheService;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.api.InstanceLayout;
 import org.apache.directory.server.core.api.schema.SchemaPartition;
@@ -209,10 +208,6 @@ class CarbonDirectoryServiceFactory {
     private void build(String name) throws Exception {
 
         directoryService.setInstanceId(name);
-        CacheService cacheService = new CacheService();
-        cacheService.initialize(directoryService.getInstanceLayout(), name);
-
-        directoryService.setCacheService(cacheService);
 
         buildWorkingDirectory(name);
 

--- a/features/org.wso2.carbon.ldap.server.server.feature/pom.xml
+++ b/features/org.wso2.carbon.ldap.server.server.feature/pom.xml
@@ -42,10 +42,6 @@
             <artifactId>commons-pool2</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.userstore.ldap</groupId>
             <artifactId>org.wso2.carbon.ldap.server</artifactId>
         </dependency>
@@ -113,7 +109,6 @@
                                 <bundleDef>org.wso2.orbit.org.apache.directory:apacheds</bundleDef>
                                 <bundleDef>org.apache.mina:mina-core</bundleDef>
                                 <bundleDef>org.apache.commons:commons-pool2</bundleDef>
-                                <bundleDef>net.sf.ehcache:ehcache</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,6 @@
                 <version>${apache.commons.pool2.version}</version>
             </dependency>
             <dependency>
-                <groupId>net.sf.ehcache</groupId>
-                <artifactId>ehcache</artifactId>
-                <version>${sf.ehcache.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${org.slf4j.verison}</version>
@@ -239,7 +234,6 @@
         <org.slf4j.verison>1.6.1</org.slf4j.verison>
         <apache.mina.version>2.1.5</apache.mina.version>
         <apache.commons.pool2.version>2.6.0</apache.commons.pool2.version>
-        <sf.ehcache.version>2.10.9.2</sf.ehcache.version>
         <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -228,9 +228,9 @@
         <carbon.identity.userstore.ldap.package.export.version>${project.version}
         </carbon.identity.userstore.ldap.package.export.version>
         <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
-        <apacheds.core.version>2.0.0.AM25</apacheds.core.version>
+        <apacheds.core.version>2.0.0.AM26</apacheds.core.version>
         <orbit.version.apacheds>${apacheds.core.version}.wso2v1</orbit.version.apacheds>
-        <apacheds.api.version>2.0.0.AM2</apacheds.api.version>
+        <apacheds.api.version>2.0.0</apacheds.api.version>
         <org.slf4j.verison>1.6.1</org.slf4j.verison>
         <apache.mina.version>2.1.5</apache.mina.version>
         <apache.commons.pool2.version>2.6.0</apache.commons.pool2.version>


### PR DESCRIPTION
Upgrading ApacheDS to 2.0.0.M26 and removing net.sf.ehcache dependency.
Since IS doesn't use the LDAPS with the embedded ldap server, removing the TLSHandler since keystore is not defined.
